### PR TITLE
seperate 'executor_GameInstanceSubsystem' and 'executor_TickableWorldSubsystem'

### DIFF
--- a/cgdk/sdk10/net.socket/socket/executor_GameInstanceSubsystem.h
+++ b/cgdk/sdk10/net.socket/socket/executor_GameInstanceSubsystem.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "../../net.socket.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "executor_GameInstanceSubsystem.generated.h"
+
+UCLASS()
+class Uexecutor_GameInstanceSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override { return true; }
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override { CGDK::executor::socket::initialize_instance(); }
+	virtual void Deinitialize() override { CGDK::executor::socket::destory_executor(); }
+
+	///** Overridden to check global network context */
+	//ENGINE_API virtual int32 GetFunctionCallspace(UFunction* Function, FFrame* Stack) override;
+
+	//virtual void Tick(float DeltaTime) override { CGDK::executor::socket::run_executor(); }
+};

--- a/cgdk/sdk10/net.socket/socket/executor_TickableWorldSubsystem.h
+++ b/cgdk/sdk10/net.socket/socket/executor_TickableWorldSubsystem.h
@@ -9,10 +9,6 @@ UCLASS()
 class Uexecutor_TickableWorldSubsystem : public UTickableWorldSubsystem
 {
 	GENERATED_BODY()
-	Uexecutor_TickableWorldSubsystem() noexcept { CGDK::executor::socket::initialize_instance(); }
-	virtual ~Uexecutor_TickableWorldSubsystem() noexcept { CGDK::executor::socket::destory_executor(); }
-	virtual TStatId GetStatId() const override { RETURN_QUICK_DECLARE_CYCLE_STAT(YouClassName, STATGROUP_Tickables); }
 	virtual void Tick(float DeltaTime) override { CGDK::executor::socket::run_executor(); }
-
-
+	virtual TStatId GetStatId() const override { RETURN_QUICK_DECLARE_CYCLE_STAT(YouClassName, STATGROUP_Tickables); }
 };

--- a/cgdk/sdk10/net.socket/socket/net.Nsocket.tcp.h
+++ b/cgdk/sdk10/net.socket/socket/net.Nsocket.tcp.h
@@ -85,7 +85,10 @@ protected:
 
 inline net::io::Nsocket_tcp::~Nsocket_tcp() noexcept
 {
-	net::io::Nsocket_tcp::process_closesocket();
+	// check) assert if socket not closed (plz closesocket then destroy)
+	ensureMsgf(this->m_flag_sending == false, TEXT("[CGDK] Assert! socket is sending(socket is not closed)"));
+	ensureMsgf(this->m_socket_status == eSOCKET_STATE::CLOSED, TEXT("[CGDK] Assert! socket status is not 'eSOCKET_STATE::CLOSED'(socket is not closed)"));
+	ensureMsgf(!this->native_handle(), TEXT("[CGDK] Assert! hancle exist(socket is not closed)"));
 }
 
 inline bool net::io::Nsocket_tcp::closesocket(uint64_t _disconnect_reason) noexcept

--- a/cgdk/sdk10/net.socket/socket/net.Nsocket.tcp_client.h
+++ b/cgdk/sdk10/net.socket/socket/net.Nsocket.tcp_client.h
@@ -181,7 +181,7 @@ inline bool net::io::Nsocket_tcp_client::process_closesocket(uint64_t _disconnec
 	// trace) 
 	UE_LOG(LogSockets, Display, TEXT("[CGDK] < socket closed (reason:%d) (%u)"), this->m_disconnect_reason, this->native_handle().Get());
 
-	// 4) detach from socket executor
+	// 3) detach from socket executor
 	if (this->m_enable_reconnect == false)
 	{
 		executor::socket::get_instance()->detach(this);
@@ -223,7 +223,7 @@ inline void net::io::Nsocket_tcp_client::process_reconnectiong()
 
 inline void net::io::Nsocket_tcp_client::process_socket_io()
 {
-	switch (get_socket_state())
+	switch (this->get_socket_state())
 	{
 	case	eSOCKET_STATE::SYN:
 			this->process_complete_connect(nullptr, 0);

--- a/cgdk/sdk10/net.socket/socket/net.Nsocket.udp.h
+++ b/cgdk/sdk10/net.socket/socket/net.Nsocket.udp.h
@@ -32,6 +32,7 @@ class net::io::Nsocket_udp :
 {
 public:
 			Nsocket_udp() {}
+	virtual ~Nsocket_udp();
 
 public:
 			bool				bind();
@@ -62,6 +63,11 @@ protected:
 private:
 			bool				m_enable_report_connect_reset;
 };
+
+inline net::io::Nsocket_udp::~Nsocket_udp()
+{
+	assert(this->native_handle().IsValid() && m_socket_status == eSOCKET_STATE::CLOSED);
+}
 
 inline TSharedPtr<FInternetAddr> net::io::Nsocket_udp::get_socket_address() const noexcept
 {
@@ -211,7 +217,7 @@ inline bool net::io::Nsocket_udp::bind(FInternetAddr& _endpoint_bind)
 	}
 
 	// 5) on_bind함수를 호출한다.
-	on_bind();
+	this->on_bind();
 
 	// 6) register to socket executor
 	executor::socket::get_instance()->attach(this->AsShared());
@@ -222,7 +228,7 @@ inline bool net::io::Nsocket_udp::bind(FInternetAddr& _endpoint_bind)
 
 inline bool net::io::Nsocket_udp::closesocket(uint64_t _disconnect_reason) noexcept
 {
-	return process_closesocket(_disconnect_reason);
+	return this->process_closesocket(_disconnect_reason);
 }
 
 inline bool net::io::Nsocket_udp::process_sendable(shared_buffer&& _buffer, std::size_t _count_message, const FInternetAddr& _address)

--- a/cgdk/sdk10/net.socket/socket/net.io.Isocket.h
+++ b/cgdk/sdk10/net.socket/socket/net.io.Isocket.h
@@ -31,9 +31,9 @@ namespace CGDK
 		virtual	~Isocket() noexcept {}
 
 	public:
-		virtual	bool				closesocket(uint64_t _disconnect_reason = DISCONNECT_REASON_NONE) noexcept PURE;
-		virtual	bool				process_closesocket(uint64_t _disconnect_reason = DISCONNECT_REASON_NONE) noexcept PURE;
-		virtual void				process_socket_io() PURE;
+		virtual	bool		closesocket(uint64_t _disconnect_reason = DISCONNECT_REASON_NONE) noexcept PURE;
+		virtual	bool		process_closesocket(uint64_t _disconnect_reason = DISCONNECT_REASON_NONE) noexcept PURE;
+		virtual void		process_socket_io() PURE;
 
 	public:
 		TSharedPtr<FSocket>	native_handle(TSharedPtr<FSocket>&& _psocket) noexcept { assert(_psocket.IsValid()); auto temp = std::move(this->m_psocket); this->m_psocket = std::move(_psocket); return temp; }


### PR DESCRIPTION
executor_TickableWorldSubsystem를 executor_GameInstanceSubsystem와 executor_TickableWorldSubsystem로 분리함.
GameInstanceSubSystem은 executor::socket을 초기화하고 파괴하는 작업만 수행하며
TickableWorldSubsystem은 reun_execute()만 수행하도록 수정.

